### PR TITLE
Fix branch selection in ruby and add tests for change addresses

### DIFF
--- a/php/test.php
+++ b/php/test.php
@@ -13,6 +13,10 @@ foreach (array(100, 65537, 4294967296) as $i) {
 	print addr_from_mpk($mpk, $i) . "\n";
 }
 
+foreach (array(0, 1, 2) as $i) {
+	print addr_from_mpk($mpk, $i, true) . "\n";
+}
+
 /*
 
 should print:
@@ -30,6 +34,9 @@ should print:
 1LNUmaHWMybREGszq8wiDTULJR3tvsjx7
 1JnjQQ5LcMDYDLNd31bEU2L5wZ9fipvEQ6
 1KJwuVF7hm7EoT1AYJas2WM3yodCzsEhAQ
+14LQiAFjVBePtffagNtsDW9TFY21Mpngka
+15GTr4N3vUDGmSrFX2XXGvwhnWqG1LzCTi
+1Q4hqqSSTTpbcr4MoigFDFhDLMMP13NorG
 
 */
 

--- a/python/test.py
+++ b/python/test.py
@@ -8,6 +8,8 @@ for i in range(10):
 	print addr_from_mpk(mpk, i)
 for i in [100, 65537, 4294967296]:
 	print addr_from_mpk(mpk, i)
+for i in range(3):
+	print addr_from_mpk(mpk, i, True)
 
 # should print:
 #
@@ -24,3 +26,6 @@ for i in [100, 65537, 4294967296]:
 # 1LNUmaHWMybREGszq8wiDTULJR3tvsjx7
 # 1JnjQQ5LcMDYDLNd31bEU2L5wZ9fipvEQ6
 # 1KJwuVF7hm7EoT1AYJas2WM3yodCzsEhAQ
+# 14LQiAFjVBePtffagNtsDW9TFY21Mpngka
+# 15GTr4N3vUDGmSrFX2XXGvwhnWqG1LzCTi
+# 1Q4hqqSSTTpbcr4MoigFDFhDLMMP13NorG

--- a/ruby/lib/bitcoin-addrgen.rb
+++ b/ruby/lib/bitcoin-addrgen.rb
@@ -3,7 +3,7 @@ module BitcoinAddrgen; end
 require 'bitcoin_addrgen/addrgen'
 
 module BitcoinAddrgen
-  def self.generate_public_address(master_public_key, address_index)
-    BitcoinAddrgen::Addrgen.addr_from_mpk(master_public_key, address_index)
+  def self.generate_public_address(master_public_key, address_index, change = false)
+    BitcoinAddrgen::Addrgen.addr_from_mpk(master_public_key, address_index, change)
   end
 end

--- a/ruby/lib/bitcoin_addrgen/addrgen.rb
+++ b/ruby/lib/bitcoin_addrgen/addrgen.rb
@@ -305,8 +305,7 @@ module BitcoinAddrgen
       # prepare the input values
       x = gmp_init(mpk[0, 64], 16)
       y = gmp_init(mpk[64, 64], 16)
-      branch = change and 1 or 0
-      z = gmp_init(sha256(sha256_raw(idx.to_s + ':' + branch.to_s + ':' + hex_to_bin(mpk))), 16)
+      z = gmp_init(sha256(sha256_raw("#{idx}:#{change ? 1 : 0}:#{hex_to_bin(mpk)}")), 16)
 
       # generate the new public key based off master and sequence points
       pt = Point.add(Point.new(curve, x, y), Point.mul(z, gen))

--- a/ruby/spec/bitcoin_addrgen_spec.rb
+++ b/ruby/spec/bitcoin_addrgen_spec.rb
@@ -52,4 +52,33 @@ describe BitcoinAddrgen do
     end
 
   end
+
+  context "generate change address" do
+    subject do
+      BitcoinAddrgen.generate_public_address(master_public_key, address_index, true)
+    end
+
+    context "with address index 0" do
+      let(:address_index) { 0 }
+      it "generates the correct public address" do
+        expect(subject).to eq('14LQiAFjVBePtffagNtsDW9TFY21Mpngka')
+      end
+    end
+
+    context "with address index 1" do
+      let(:address_index) { 1 }
+      it "generates the correct public address" do
+        expect(subject).to eq('15GTr4N3vUDGmSrFX2XXGvwhnWqG1LzCTi')
+      end
+    end
+
+    context "with address index 2" do
+      let(:address_index) { 2 }
+      it "generates the correct public address" do
+        expect(subject).to eq('1Q4hqqSSTTpbcr4MoigFDFhDLMMP13NorG')
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
Looks like this statement is interpreted differently than in python. It should be:

`branch = (change and 1 or 0)`

but without the explicit grouping, ruby seems to parse it like:

`(branch = change and 1) or 0`

so the branch variable ends up being `false` instead of `0` and the wrong address is generated.

It even looks correct in irb at first, I had to look twice until I noticed it:
```
> a = false and 1 or 0
 => 0
> a
 => false
> a = (false and 1 or 0)
 => 0 
> a
 => 0 
```

Changed it to a ternary operator, just to be sure, and shortened the string concatenation a little.
Also added some tests for change addresses.

Thanks for this gem btw! Could you update the version when you get a change? :)