### PR TITLE
Add support for different address versions (for testnet)

### DIFF
--- a/php/test.php
+++ b/php/test.php
@@ -13,6 +13,10 @@ foreach (array(100, 65537, 4294967296) as $i) {
 	print addr_from_mpk($mpk, $i) . "\n";
 }
 
+foreach (array(0, 1, 2) as $i) {
+	print addr_from_mpk($mpk, $i, true) . "\n";
+}
+
 /*
 
 should print:
@@ -30,6 +34,9 @@ should print:
 1LNUmaHWMybREGszq8wiDTULJR3tvsjx7
 1JnjQQ5LcMDYDLNd31bEU2L5wZ9fipvEQ6
 1KJwuVF7hm7EoT1AYJas2WM3yodCzsEhAQ
+14LQiAFjVBePtffagNtsDW9TFY21Mpngka
+15GTr4N3vUDGmSrFX2XXGvwhnWqG1LzCTi
+1Q4hqqSSTTpbcr4MoigFDFhDLMMP13NorG
 
 */
 

--- a/python/addrgen.py
+++ b/python/addrgen.py
@@ -26,6 +26,8 @@ import hashlib
 import gmpy
 from binascii import unhexlify
 
+VERSION_BYTES = { 'bitcoin': '00', 'testnet': '6f' }
+
 class Curve:
 
 	def __init__(self, prime, a, b):
@@ -151,7 +153,7 @@ def ripemd160(s):
 	h.update(s)
 	return h.hexdigest()
 
-def addr_from_mpk(mpk, idx, change = False):
+def addr_from_mpk(mpk, idx, change = False, version = 'bitcoin'):
 	# create the ecc curve
 	_p  = gmpy.mpz('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F', 16)
 	_r  = gmpy.mpz('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141', 16)
@@ -172,7 +174,7 @@ def addr_from_mpk(mpk, idx, change = False):
 
 	keystr = unhexlify('04' + hex(pt.x)[2:].zfill(64) + hex(pt.y)[2:].zfill(64))
 
-	vh160 = '00' + ripemd160(sha256(keystr).digest())
+	vh160 = VERSION_BYTES[version] + ripemd160(sha256(keystr).digest())
 	addr = vh160 + sha256(sha256(unhexlify(vh160)).digest()).hexdigest()[0:8]
 
 	__b58chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'

--- a/python/test.py
+++ b/python/test.py
@@ -1,31 +1,55 @@
 #!/usr/bin/python
 
+import unittest
 from addrgen import addr_from_mpk
 
-mpk = '675b7041a347223984750fe3ab229df0c9f960e7ec98226b7182a2cb1990e39901feecf5a670f1d788ab29f626e20de424f049d216fc6f4c6ec42506763fa28e'
+class AddrgenTest(unittest.TestCase):
 
-for i in range(10):
-	print addr_from_mpk(mpk, i)
-for i in [100, 65537, 4294967296]:
-	print addr_from_mpk(mpk, i)
-for i in range(3):
-	print addr_from_mpk(mpk, i, True)
+	def setUp(self):
+		self.mpk = '675b7041a347223984750fe3ab229df0c9f960e7ec98226b7182a2cb1990e39901feecf5a670f1d788ab29f626e20de424f049d216fc6f4c6ec42506763fa28e'
 
-# should print:
-#
-# 13EfJ1hQBGMBbEwvPa3MLeH6buBhiMSfCC
-# 1AZW6GGmsUizkHhrtg853Qnxk68vCx2gFq
-# 1M7ReiRrcYygYYLdyPS2cKQi7p9s9ViFS1
-# 1NcawzHFoECpDhz8hUCZp43hGjvdEB8DBA
-# 1PjcUN9kEBn3kvUmT2BXezwTG4RRvrqjRw
-# 16QNfbdLoKkMKtQR3MK8uisss7YAF88Yv4
-# 1jmA5ySdFz7cDwWb15rWQe63ZUo8spiBa
-# 1BsHKTsi3umme8xv4GbrPxGCfQ2feJYZAV
-# 16uCFEcanBtRPAwn6GhkFtmVeurrkbgt1U
-# 1J7yTE8Cm9fMV9nqCjnM6kTTzTkksVic98
-# 1LNUmaHWMybREGszq8wiDTULJR3tvsjx7
-# 1JnjQQ5LcMDYDLNd31bEU2L5wZ9fipvEQ6
-# 1KJwuVF7hm7EoT1AYJas2WM3yodCzsEhAQ
-# 14LQiAFjVBePtffagNtsDW9TFY21Mpngka
-# 15GTr4N3vUDGmSrFX2XXGvwhnWqG1LzCTi
-# 1Q4hqqSSTTpbcr4MoigFDFhDLMMP13NorG
+
+	# regular addresses
+
+	def test_address_0(self):
+		addr = addr_from_mpk(self.mpk, 0)
+		self.assertEqual(addr, '13EfJ1hQBGMBbEwvPa3MLeH6buBhiMSfCC')
+
+	def test_address_6(self):
+		addr = addr_from_mpk(self.mpk, 6)
+		self.assertEqual(addr, '1jmA5ySdFz7cDwWb15rWQe63ZUo8spiBa')
+
+	def test_address_9(self):
+		addr = addr_from_mpk(self.mpk, 9)
+		self.assertEqual(addr, '1J7yTE8Cm9fMV9nqCjnM6kTTzTkksVic98')
+
+	def test_address_100(self):
+		addr = addr_from_mpk(self.mpk, 100)
+		self.assertEqual(addr, '1LNUmaHWMybREGszq8wiDTULJR3tvsjx7')
+
+	def test_address_65537(self):
+		addr = addr_from_mpk(self.mpk, 65537)
+		self.assertEqual(addr, '1JnjQQ5LcMDYDLNd31bEU2L5wZ9fipvEQ6')
+
+	def test_address_4294967296(self):
+		addr = addr_from_mpk(self.mpk, 4294967296)
+		self.assertEqual(addr, '1KJwuVF7hm7EoT1AYJas2WM3yodCzsEhAQ')
+
+
+	# change addresses
+
+	def test_change_address_0(self):
+		addr = addr_from_mpk(self.mpk, 0, True)
+		self.assertEqual(addr, '14LQiAFjVBePtffagNtsDW9TFY21Mpngka')
+
+	def test_change_address_1(self):
+		addr = addr_from_mpk(self.mpk, 1, True)
+		self.assertEqual(addr, '15GTr4N3vUDGmSrFX2XXGvwhnWqG1LzCTi')
+
+	def test_change_address_2(self):
+		addr = addr_from_mpk(self.mpk, 2, True)
+		self.assertEqual(addr, '1Q4hqqSSTTpbcr4MoigFDFhDLMMP13NorG')
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/python/test.py
+++ b/python/test.py
@@ -8,6 +8,8 @@ for i in range(10):
 	print addr_from_mpk(mpk, i)
 for i in [100, 65537, 4294967296]:
 	print addr_from_mpk(mpk, i)
+for i in range(3):
+	print addr_from_mpk(mpk, i, True)
 
 # should print:
 #
@@ -24,3 +26,6 @@ for i in [100, 65537, 4294967296]:
 # 1LNUmaHWMybREGszq8wiDTULJR3tvsjx7
 # 1JnjQQ5LcMDYDLNd31bEU2L5wZ9fipvEQ6
 # 1KJwuVF7hm7EoT1AYJas2WM3yodCzsEhAQ
+# 14LQiAFjVBePtffagNtsDW9TFY21Mpngka
+# 15GTr4N3vUDGmSrFX2XXGvwhnWqG1LzCTi
+# 1Q4hqqSSTTpbcr4MoigFDFhDLMMP13NorG

--- a/python/test.py
+++ b/python/test.py
@@ -51,5 +51,20 @@ class AddrgenTest(unittest.TestCase):
 		self.assertEqual(addr, '1Q4hqqSSTTpbcr4MoigFDFhDLMMP13NorG')
 
 
+	# testnet addresses
+
+	def test_testnet_address_0(self):
+		addr = addr_from_mpk(self.mpk, 0, False, 'testnet')
+		self.assertEqual(addr, 'mhkcb4nNzHnSNMRY791jAZVRTtnQa3QKT3')
+
+	def test_testnet_address_1(self):
+		addr = addr_from_mpk(self.mpk, 1, False, 'testnet')
+		self.assertEqual(addr, 'mq5TPKMkgWAFXQBUcF6SsL1Hc5jdBFy2q7')
+
+	def test_testnet_address_2(self):
+		addr = addr_from_mpk(self.mpk, 2, False, 'testnet')
+		self.assertEqual(addr, 'n1dNwmWqRaQwKepFgxQQSEd2yoka4B85oo')
+
+
 if __name__ == '__main__':
 	unittest.main()

--- a/ruby/lib/bitcoin-addrgen.rb
+++ b/ruby/lib/bitcoin-addrgen.rb
@@ -3,7 +3,7 @@ module BitcoinAddrgen; end
 require 'bitcoin_addrgen/addrgen'
 
 module BitcoinAddrgen
-  def self.generate_public_address(master_public_key, address_index, change = false)
-    BitcoinAddrgen::Addrgen.addr_from_mpk(master_public_key, address_index, change)
+  def self.generate_public_address(master_public_key, address_index, change = false, version = :bitcoin)
+    BitcoinAddrgen::Addrgen.addr_from_mpk(master_public_key, address_index, change, version)
   end
 end

--- a/ruby/lib/bitcoin-addrgen.rb
+++ b/ruby/lib/bitcoin-addrgen.rb
@@ -3,7 +3,7 @@ module BitcoinAddrgen; end
 require 'bitcoin_addrgen/addrgen'
 
 module BitcoinAddrgen
-  def self.generate_public_address(master_public_key, address_index)
-    BitcoinAddrgen::Addrgen.addr_from_mpk(master_public_key, address_index)
+  def self.generate_public_address(master_public_key, address_index, change = false)
+    BitcoinAddrgen::Addrgen.addr_from_mpk(master_public_key, address_index, change)
   end
 end

--- a/ruby/lib/bitcoin_addrgen/addrgen.rb
+++ b/ruby/lib/bitcoin_addrgen/addrgen.rb
@@ -305,8 +305,7 @@ module BitcoinAddrgen
       # prepare the input values
       x = gmp_init(mpk[0, 64], 16)
       y = gmp_init(mpk[64, 64], 16)
-      branch = change and 1 or 0
-      z = gmp_init(sha256(sha256_raw(idx.to_s + ':' + branch.to_s + ':' + hex_to_bin(mpk))), 16)
+      z = gmp_init(sha256(sha256_raw("#{idx}:#{change ? 1 : 0}:#{hex_to_bin(mpk)}")), 16)
 
       # generate the new public key based off master and sequence points
       pt = Point.add(Point.new(curve, x, y), Point.mul(z, gen))

--- a/ruby/lib/bitcoin_addrgen/addrgen.rb
+++ b/ruby/lib/bitcoin_addrgen/addrgen.rb
@@ -277,6 +277,9 @@ module BitcoinAddrgen
   end
 
   class Addrgen
+
+    VERSION_BYTES = { bitcoin: '00', testnet: '6f' }
+
     def self.hex_to_bin(s)
       [s].pack('H*')
     end
@@ -293,7 +296,7 @@ module BitcoinAddrgen
       Digest::RMD160.hexdigest(data)
     end
 
-    def self.addr_from_mpk(mpk, idx, change = false)
+    def self.addr_from_mpk(mpk, idx, change = false, version = :bitcoin)
       _p  = gmp_init('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F', 16)
       _r  = gmp_init('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141', 16)
       _b  = gmp_init('0000000000000000000000000000000000000000000000000000000000000007', 16)
@@ -310,7 +313,8 @@ module BitcoinAddrgen
       # generate the new public key based off master and sequence points
       pt = Point.add(Point.new(curve, x, y), Point.mul(z, gen))
       keystr = hex_to_bin('04' + gmp_strval(pt.x, 16).rjust(64, '0') + gmp_strval(pt.y, 16).rjust(64, '0'))
-      vh160 =  '00' + ripemd160(sha256_raw(keystr))
+
+      vh160 = VERSION_BYTES[version.to_sym] + ripemd160(sha256_raw(keystr))
       addr = vh160 + sha256(sha256_raw(hex_to_bin(vh160)))[0, 8]
 
       num = gmp_strval(gmp_init(addr, 16), 58)

--- a/ruby/spec/bitcoin_addrgen_spec.rb
+++ b/ruby/spec/bitcoin_addrgen_spec.rb
@@ -52,4 +52,33 @@ describe BitcoinAddrgen do
     end
 
   end
+
+  context "generate change address" do
+    subject do
+      BitcoinAddrgen.generate_public_address(master_public_key, address_index, true)
+    end
+
+    context "with address index 0" do
+      let(:address_index) { 0 }
+      it "generates the correct public address" do
+        expect(subject).to eq('14LQiAFjVBePtffagNtsDW9TFY21Mpngka')
+      end
+    end
+
+    context "with address index 1" do
+      let(:address_index) { 1 }
+      it "generates the correct public address" do
+        expect(subject).to eq('15GTr4N3vUDGmSrFX2XXGvwhnWqG1LzCTi')
+      end
+    end
+
+    context "with address index 2" do
+      let(:address_index) { 2 }
+      it "generates the correct public address" do
+        expect(subject).to eq('1Q4hqqSSTTpbcr4MoigFDFhDLMMP13NorG')
+      end
+    end
+
+  end
+
 end

--- a/ruby/spec/bitcoin_addrgen_spec.rb
+++ b/ruby/spec/bitcoin_addrgen_spec.rb
@@ -81,4 +81,32 @@ describe BitcoinAddrgen do
 
   end
 
+  context "generate testnet address" do
+    subject do
+      BitcoinAddrgen.generate_public_address(master_public_key, address_index, false, :testnet)
+    end
+
+    context "with address index 0" do
+      let(:address_index) { 0 }
+      it "generates the correct public address" do
+        expect(subject).to eq('mhkcb4nNzHnSNMRY791jAZVRTtnQa3QKT3')
+      end
+    end
+
+    context "with address index 1" do
+      let(:address_index) { 1 }
+      it "generates the correct public address" do
+        expect(subject).to eq('mq5TPKMkgWAFXQBUcF6SsL1Hc5jdBFy2q7')
+      end
+    end
+
+    context "with address index 1" do
+      let(:address_index) { 2 }
+      it "generates the correct public address" do
+        expect(subject).to eq('n1dNwmWqRaQwKepFgxQQSEd2yoka4B85oo')
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
I'm not sure about the state of testnet support with electrum in general, and if anybody is generating testnet addresses from electrum MPKs at all. Anyway, it matches the addresses produced by https://github.com/wozz/electrum/tree/testnet.

This is useful to me so I can use it in an existing test suite that uses testnet everywhere.